### PR TITLE
Make non-database-dependend dummy-app runnable in development mode

### DIFF
--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -23,11 +23,11 @@ Dummy::Application.configure do
   config.action_dispatch.best_standards_support = :builtin
 
   # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
+  # config.active_record.mass_assignment_sanitizer = :strict
 
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
-  config.active_record.auto_explain_threshold_in_seconds = 0.5
+  # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
   # Do not compress assets
   config.assets.compress = false


### PR DESCRIPTION
I got a 
`configuration.rb:85:in `method_missing': undefined method `active_record' for #<Rails::Application::Configuration` 
error when trying to run the dummy app in **development** mode.
