### PR TITLE
Option to disable basic auth

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -117,6 +117,9 @@ You can create the initializer for evercookie gem in your Rails application init
 
     # cookie name for etag storage
     config.cookie_etag = :evercookie_etag
+
+    # enable/disable http basic auth (leads to problems if your app uses http basic auth)
+    config.basic_auth = true
   end
 
 === Hiding evercookie presence in your application

--- a/app/assets/javascripts/evercookie/evercookie.js.erb
+++ b/app/assets/javascripts/evercookie/evercookie.js.erb
@@ -111,7 +111,11 @@ try{
     baseurl: '', // base url for php, flash and silverlight assets
     silverlight: false, // you might want to turn it off https://github.com/samyk/evercookie/issues/45
     domain: '.' + window.location.host.replace(/:\d+/, ''), // Get current domain
+    <% if Evercookie.basic_auth %>
     authPath: '<%= Evercookie.get_auth_path %>', // set to false to disable Basic Authentication cache
+    <% else %>
+    authPath: false, // set to false to disable Basic Authentication cache
+    <% end %>
     pngCookieName: '<%= Evercookie.cookie_png %>',
     pngPath: '<%= Evercookie.get_png_path %>',
     etagCookieName: '<%= Evercookie.cookie_etag %>',

--- a/lib/evercookie.rb
+++ b/lib/evercookie.rb
@@ -29,6 +29,10 @@ module Evercookie
   mattr_accessor :hash_name
   @@hash_name = :evercookie
 
+  # enable/disable basic authentication cache
+  mattr_accessor :basic_auth
+  @@basic_auth = true
+
   # default method for setup evercookie
   def self.setup
     yield self


### PR DESCRIPTION
This adds an option to disable http basic auth (because I had some problems in my application which uses basic auth. The auth popup keeps popping up on every page, which is rather annoying).

Unfortunately I did not find out how to add tests for that, but if you give me some hint, I can do that, too.
